### PR TITLE
Include common boolean-emoji expressions

### DIFF
--- a/Sources/NopeYep/NopeYep.swift
+++ b/Sources/NopeYep/NopeYep.swift
@@ -3,9 +3,9 @@ import Foundation
 extension Bool: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         switch value.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) {
-        case "nope","","0","nan","👎","👎🏻","👎🏼","👎🏽","👎🏾","👎🏿", "no yeah":
+        case "nope","","0","nan","👎","👎🏻","👎🏼","👎🏽","👎🏾","👎🏿","❌","no yeah":
             self = false
-        case "yep","1","0 but true","👍","👍🏻","👍🏼","👍🏽","👍🏾","👍🏿", "yeah no", "for sure":
+        case "yep","1","0 but true","👍","👍🏻","👍🏼","👍🏽","👍🏾","👍🏿","✔️","yeah no", "for sure":
             self = true
         case "maybe", "🤷🏼‍♂️":
             self = Bool.random()


### PR DESCRIPTION
It's highly desirable to extend this package to support very common and standard emoji representations of booleans. I can't be the only one who defines the following global constants in all of my Swift projects?
```
let ✔️ = true
let ❌ = false
```
If this change is merged, then I can use this package and remove these variables from my codebases.