### PR TITLE
Remove multiple skin tone checks

### DIFF
--- a/Sources/NopeYep/NopeYep.swift
+++ b/Sources/NopeYep/NopeYep.swift
@@ -2,10 +2,10 @@ import Foundation
 
 extension Bool: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        switch value.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) {
-        case "nope","","0","nan","👎","👎🏻","👎🏼","👎🏽","👎🏾","👎🏿","❌","no yeah":
+        switch value.lowercased().trimmingCharacters(in: .whitespacesAndNewlines).returningScalar {
+        case "nope","","0","nan","👎","❌","no yeah":
             self = false
-        case "yep","1","0 but true","👍","👍🏻","👍🏼","👍🏽","👍🏾","👍🏿","✔️","yeah no", "for sure":
+        case "yep","1","0 but true","👍","✔️","yeah no", "for sure":
             self = true
         case "maybe", "🤷🏼‍♂️":
             self = Bool.random()

--- a/Sources/NopeYep/String+Extension.swift
+++ b/Sources/NopeYep/String+Extension.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension String {
+    var returningScalar: String {
+        guard self.count == 1, let scalars = unicodeScalars.first else { return self }
+        return String(scalars)
+    }
+}


### PR DESCRIPTION
### What is this?
This PR can reduce the need to hard code skin tone emojis values by creating an extension on String to read the scalar of the string.

### How
If the count of the characters in the string is equal to 1 (essentially not a word or phrase) it will return the first [Unicode.Scalar](https://developer.apple.com/documentation/swift/unicode/scalar).
In the case of different skin tone emojis, the scalar utilizes the base emoji and the Fitzpatrick scale.
Xcode creates this by automagically concatenating the emoji: `👍` and the Fitzpatrick scale `🏽`.

### Drawbacks
*The implementation is not without faults.*
There may be edge cases I haven't considered, but I would love to hear what others think! I really liked this idea!